### PR TITLE
Fix No Client ID Found

### DIFF
--- a/rpc.js
+++ b/rpc.js
@@ -2,7 +2,7 @@ const { Client } = require('discord-rpc'),
       monitor = require('active-win');
 
 const client = new Client({ transport: 'ipc' }),
-      clientID = '513802765139574786';
+      clientId = '513802765139574786';
 
 var currentFile = null;
 
@@ -64,4 +64,4 @@ client.on('ready', () => {
   }, 15000);
 });
 
-client.login(clientID).catch(console.error);
+client.login({ clientId }).catch(console.error);


### PR DESCRIPTION
Pretty simple fix. Discord-rpc requires an object input, not just the ID itself.

Fixes #3, Fixes #1 